### PR TITLE
Add GIT_TERMINAL_PROMPT=0 to bypass auth prompt

### DIFF
--- a/codearchives.sh
+++ b/codearchives.sh
@@ -1,6 +1,9 @@
 scriptdir=$(pwd)
 workingdir=~/archives
 
+# don't prompt for user/pass, just keep going
+export GIT_TERMINAL_PROMPT=0
+
 # initial grabbing, simply errors if the directory exists so re-running on the same repo does not hurt
 cd "${workingdir}"
 echo "git cloning"


### PR DESCRIPTION
As of git 2.3 this env var was added to have git not prompt for auth if necessary so batch jobs can run with no input.